### PR TITLE
Added support for ember modifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
             "mixins",
             "utils",
             "serializers",
-            "adapters"
+            "adapters",
+            "modifiers"
           ]
         },
         "fileHopper.testSubRootFolders": {


### PR DESCRIPTION
## Summary
Ember modifiers are generated inside the `modifiers` folder in the app/addon. I have added `modifiers` path to `appSubFolders` config option so that it will be possible for the developer to hop from test case to modifier file.

## Screenshots
<img width="1034" alt="Screen Shot 2022-04-06 at 4 50 53 PM" src="https://user-images.githubusercontent.com/792903/162130077-7a9bbbb1-ca96-414e-8199-546ba6e7d539.png">
<img width="1035" alt="Screen Shot 2022-04-06 at 4 51 06 PM" src="https://user-images.githubusercontent.com/792903/162130097-ee832049-17b0-4811-bb47-9b8cc512ff02.png">

