### PR TITLE
add support for .gjs & .gts format

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,8 @@
           "default": [
             "js",
             "ts",
+            "gjs",
+            "gts",
             "html",
             "hbs",
             "css",


### PR DESCRIPTION
With [ember-template-imports](https://github.com/ember-template-imports/ember-template-imports), Ember apps now support two new custom file extensions for writing components 
- `.gjs` Glimmer Javascript 
- `.gts` Glimmer Typescript

This PR adds support for these new file extensions to find related files such as `*-test.js`, `.scss` etc.

---
Find more details at [ember-template-imports blog series](https://v5.chriskrycho.com/journal/ember-template-imports/)